### PR TITLE
Resolve unbound variable with CONFIG_PROTECT_MASK

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4788,7 +4788,7 @@ __gentoo_config_protection() {
     # this point, manually merge the changes using etc-update/dispatch-conf/
     # cfg-update and then restart the bootstrapping script, so instead we allow
     # at this point to modify certain config files directly
-    export CONFIG_PROTECT_MASK="$CONFIG_PROTECT_MASK /etc/portage/package.keywords /etc/portage/package.unmask /etc/portage/package.use /etc/portage/package.license"
+    export CONFIG_PROTECT_MASK=: "${CONFIG_PROTECT_MASK:=/etc/portage/package.keywords /etc/portage/package.unmask /etc/portage/package.use /etc/portage/package.license}"
 }
 
 __gentoo_pre_dep() {


### PR DESCRIPTION
Without this change, bootstrap-salt.sh fails complaining of an unbound variable.  This syntax corrects this issue and allows bootstrap-salt.sh to resume its installation.
